### PR TITLE
Added functionality to auto-configure mount options at installation

### DIFF
--- a/TODOLIST.md
+++ b/TODOLIST.md
@@ -5,6 +5,6 @@
 - [ ] Add alias (with proper names) to commands in scripts file, add them to install.sh
 - [ ] Make squid **selinux** compatible
 - [ ] Install latest kernel available by default instead of default 
-- [ ] Configure mount options in "/etc/fstab" with the help of install script itself
+- [X] Configure mount options in "/etc/fstab" with the help of install script itself
 - [ ] Add a script to turn on squid if it has crashed
 - [ ] Add squid workers for SMP support

--- a/install.sh
+++ b/install.sh
@@ -55,6 +55,29 @@ then
               #rpm --import https://www.elrepo.org/RPM-GPG-KEY-elrepo.org
               #rpm -Uvh http://www.elrepo.org/elrepo-release-7.0-2.el7.elrepo.noarch.rpm
               #yum --enablerepo=elrepo-kernel -y install kernel-ml
+              
+              echo "Auto-Configure mount options? (Y/n)"
+              read -r option
+              if ! [[ $option =~ N|n ]]; then     
+                     while [[ true ]]; do
+                            echo -n "Enter absolute cache directory (eg: /cache) "
+                            read -r cache_dir
+                            if [[ -z $cache_dir  ]]; then
+                                   cache_dir="/cache"
+                                   echo "$(tput bold)WARNING$(tput sgr0): Using /cache as cache directory"
+                                   echo -n "Continue (Y/n)"
+                                   read -r confirm
+                                   if ! [[ $confirm =~ N|n ]] ; then
+                                          break;
+                                   fi
+                            fi
+                     done
+                     # Partition on which cache is mounted, sed pipe replaces "/" with "\/"
+                     cache_prt=$(mount | grep $cache_dir | awk '{print $1}' | sed 's:/:\\/:g')
+                     # search for line containing cache_prt in  /etc/fstab, replace defaults with default,noatime
+                     options="defaults,noatime"
+                     sed -i '/'"$cache_prt"'/ s/defaults/'"$options"'/' /etc/fstab
+              fi
        else
               echo "IP not valid"
        fi

--- a/scripts
+++ b/scripts
@@ -4,5 +4,8 @@ netstat -an | grep 3128 | awk -F ":" '{print $2|"sort -uV"}'| awk '{print $2}'
 #list number of connected users
 netstat -an | grep 3128 | awk -F ":" '{print $2|"sort -uV"}'| wc -l
 
+# ping default gateway
+ping -c10 $(ip route show default | awk '/default/ {print $3}')
+
 #set date
 date -s "$(wget -qSO- --max-redirect=0 google.com 2>&1 | grep Date: | cut -d' ' -f5-8)Z"


### PR DESCRIPTION
The while loop can be safely replaced with

    `cache_dir="/cache"`

While loop's purpose is just assured Input from user.
The variable **options** should contain commas to separate different mount options.

